### PR TITLE
Fixed ParseBytes and ParseFile by adding a agclearerrors in C

### DIFF
--- a/_examples/parse_bytes.go
+++ b/_examples/parse_bytes.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/goccy/go-graphviz"
+)
+
+func _main() error {
+	gviz := graphviz.New()
+	_, err_1 := graphviz.ParseBytes([]byte("graph test { a -- b }")) // no error
+	_, err_2 := graphviz.ParseBytes([]byte("graph test { a -- b"))   // error
+	_, err_3 := graphviz.ParseBytes([]byte("graph test { a -- b }")) // no error
+	_, err_4 := graphviz.ParseBytes([]byte("graph test { a -- }"))   // error
+	_, err_5 := graphviz.ParseBytes([]byte("graph test { a -- c }")) // no error
+	_, err_6 := graphviz.ParseBytes([]byte("graph test { a - b }"))  // error
+	_, err_7 := graphviz.ParseBytes([]byte("graph test { c -- b }")) // no error
+
+	if err_1 != nil {
+		fmt.Println(err_1)
+		panic("Test 1 of ParseBytes: Failed")
+	}
+
+	if err_2 == nil {
+		fmt.Println(err_2)
+		panic("Test 2 of ParseBytes: Failed")
+	}
+
+	if err_3 != nil {
+		fmt.Println(err_3)
+		panic("Test 3 of ParseBytes: Failed")
+	}
+
+	if err_4 == nil {
+		fmt.Println(err_4)
+		panic("Test 4 of ParseBytes: Failed")
+	}
+
+	if err_5 != nil {
+		fmt.Println(err_5)
+		panic("Test 5 of ParseBytes: Failed")
+	}
+
+	if err_6 == nil {
+		fmt.Println(err_6)
+		panic("Test 6 of ParseBytes: Failed")
+	}
+
+	if err_7 != nil {
+		fmt.Println(err_7)
+		panic("Test 7 of ParseBytes: Failed")
+	}
+
+	gviz.Close()
+	return nil
+}
+
+func main() {
+	if err := _main(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cgraph/cgraph.go
+++ b/cgraph/cgraph.go
@@ -101,6 +101,7 @@ func toEdge(e *ccall.Agedge) *Edge {
 }
 
 func ParseBytes(bytes []byte) (*Graph, error) {
+	ccall.Agclearerrors()
 	graph, err := ccall.Agmemread(string(bytes))
 	if err != nil {
 		return nil, err

--- a/cgraph/cgraph.go
+++ b/cgraph/cgraph.go
@@ -114,6 +114,7 @@ func ParseFile(path string) (*Graph, error) {
 	if err != nil {
 		return nil, err
 	}
+	ccall.Agclearerrors()
 	graph, err := ccall.Agmemread(string(file))
 	if err != nil {
 		return nil, err

--- a/internal/ccall/cgraph.go
+++ b/internal/ccall/cgraph.go
@@ -1182,6 +1182,10 @@ func Agerr(msg string) {
 	C.free(unsafe.Pointer(s))
 }
 
+func Agclearerrors() {
+	C.agclearerrors()
+}
+
 func init() {
 	C.agseterr(C.AGMAX)
 }

--- a/internal/ccall/cgraph/agerror.c
+++ b/internal/ccall/cgraph/agerror.c
@@ -2,7 +2,7 @@
 /* vim:set shiftwidth=4 ts=8: */
 
 /*************************************************************************
- * Copyright (c) 2011 AT&T Intellectual Property 
+ * Copyright (c) 2011 AT&T Intellectual Property
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -59,7 +59,7 @@ char *aglasterr()
 }
 
 /* userout:
- * Report messages using a user-supplied write function 
+ * Report messages using a user-supplied write function
  */
 static void
 userout (agerrlevel_t level, const char *fmt, va_list args)
@@ -169,10 +169,16 @@ void agwarningf(const char *fmt, ...)
 
 int agerrors() { return agmaxerr; }
 
-int agreseterrors() 
-{ 
+int agreseterrors()
+{
     int rc = agmaxerr;
     agmaxerr = 0;
-    return rc; 
+    return rc;
 }
 
+void agclearerrors()
+{
+    fclose(agerrout);
+    agerrout = NULL;
+    aglast = 0;
+}

--- a/internal/ccall/cgraph/cgraph.h
+++ b/internal/ccall/cgraph/cgraph.h
@@ -2,7 +2,7 @@
 /* vim:set shiftwidth=4 ts=8: */
 
 /*************************************************************************
- * Copyright (c) 2011 AT&T Intellectual Property 
+ * Copyright (c) 2011 AT&T Intellectual Property
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -388,6 +388,7 @@ extern void agerrorf(const char *fmt, ...);
 extern void agwarningf(const char *fmt, ...);
 extern int agerrors(void);
 extern int agreseterrors(void);
+extern void agclearerrors(void);
 extern agusererrf agseterrf(agusererrf);
 
 /* data access macros */


### PR DESCRIPTION
A fix for the bug described by issue #60.

In summary, this PR introduces `agclearerrors()` in the C code, which closes and resets the output file for error reporting. In the `ccall` package, a binding is created via `Agclearerrors()` function.

`ParseBytes()` and `ParseFile()` in the `cgraph` package now call `Agclearerrors()` before reading and parsing the buffer to ensure there are no extraneous errors left over, and that the call to `Aglasterr()` returns only new errors produced by parsing.